### PR TITLE
fix:トップと診断結果におけるログインの配置修正

### DIFF
--- a/app/views/questions/result.html.erb
+++ b/app/views/questions/result.html.erb
@@ -13,7 +13,11 @@
         </div>
       <div class="row justify-content-center align-items-center">
         <div class="col-auto">
-          <%= link_to 'トップに戻る', root_path, class: 'btn btn-share' %>
+          <% if user_signed_in? %>
+            <%= link_to 'トップに戻る', root_path, class: 'btn btn-share' %>
+          <% else %>
+            <%= render 'shared/auth_buttons' %>
+          <% end %>
         </div>
         <div class="twitter col-auto">
           <%= link_to "https://x.com/share?url=https://portfolio-2-xm41.onrender.com&text=【あなたはどんな冷え性？】%0a%0a#{ @cold_symptom.symptom_title}%0a%0a %23HieMiru %23冷え性", target: '_blank', class: 'btn btn-share' do %>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -10,9 +10,13 @@
           <div class="sub-chatch mt-10">
             <h4 class="text-start">「冷え診る」は<br>診断からはじまる<br><span class="fw-bolder pink">”冷え性の見える化”</span>で<br>冷えの改善をサポートします。</h4>
             <p class="text-start">※スマホ利用を想定したアプリです。<br>PCでは正常に作動しない場合がございます。</p>
-            <%= render 'shared/auth_buttons' %>
-            <h5 class="text-start">ログインせずに診断機能を</h5>
-            <%= link_to '試してみる', questions_path, class: 'btn btn-success' %><br><br>
+            <% if user_signed_in? %>
+              <%= link_to '診断機能', questions_path, class: 'btn btn-success' %><br><br>
+            <% else %>
+              <%= render 'shared/auth_buttons' %>
+              <h5 class="text-start">ログインせずに診断機能を</h5>
+              <%= link_to '試してみる', questions_path, class: 'btn btn-success' %><br><br>
+            <% end %>
             <h4 class="text-start fw-bolder">冷え診るで出来ること</h4>
           </div>
           <div>


### PR DESCRIPTION
- 診断機能からユーザー登録に繋げられていなかったため、その動線を確保
- トップ画面に、ログイン後もログインのボタンが配置されていたため、ログイン後はログインボタンを削除