### PR TITLE
fix:READMEの画像の大きさ修正#252

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 
 |通知設定機能|通知表示画面|
 |:-------------|:-------------|
-|[![Image from Gyazo](https://i.gyazo.com/714bae5046ac923a1bee2bed9c6c1362.gif)](https://gyazo.com/714bae5046ac923a1bee2bed9c6c1362)|[![Image from Gyazo](https://i.gyazo.com/39fe88940c4dca24ea06b4d184d75f28.png)](https://gyazo.com/39fe88940c4dca24ea06b4d184d75f28)|
+|[![Image from Gyazo](https://i.gyazo.com/714bae5046ac923a1bee2bed9c6c1362.gif)](https://gyazo.com/714bae5046ac923a1bee2bed9c6c1362)|[![Image from Gyazo](https://i.gyazo.com/5f78314465d9e6188d6e724b4cf659c1.png)](https://gyazo.com/5f78314465d9e6188d6e724b4cf659c1)|
 |目標を設定する画面にて通知に必要なLINE友達追加の設定を行います。|実際の通知画面です。|
 
 ### その他機能：


### PR DESCRIPTION
- 画像の大きさが釣り合っていなかったため、画像の差し替え